### PR TITLE
Fix mismatch File[debconf.snoopy.preseed]

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,7 +31,7 @@ class snoopy ($package = true, $service = true) {
       require      => File['debconf.snoopy.preseed'],
     }
 
-    file { '/tmp/debconf.snoopy.preseed':
+    file { 'debconf.snoopy.preseed':
       ensure  => present,
       path    => '/tmp/debconf.snoopy.preseed',
       mode    => '0400',


### PR DESCRIPTION
I ve got this: 
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Invalid relationship: Package[snoopy] { require => File[debconf.snoopy.preseed] }, because File[debconf.snoopy.preseed] doesn't seem to be in the catalog